### PR TITLE
Fix voice init require error

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -3,6 +3,9 @@ import next from 'next';
 import { KokoroTTS } from 'kokoro-js';
 import path from 'path';
 import fs from 'fs/promises';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
 
 const dev = process.env.NODE_ENV !== 'production';
 const nextApp = next({ dev });


### PR DESCRIPTION
## Summary
- ensure `require` is available in ESM server

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails to download SWC binary)*

------
https://chatgpt.com/codex/tasks/task_b_6861583aa470832ba5278dbdded05484