### PR TITLE
Fix kokoro-js voice resolution

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -26,7 +26,7 @@ async function getModel() {
 
 async function ensureVoices() {
   try {
-    const distPath = path.dirname(require.resolve('kokoro-js/dist/kokoro.js'));
+    const distPath = path.dirname(require.resolve('kokoro-js'));
     const distVoices = path.join(distPath, 'voices');
     const rootVoices = path.resolve(process.cwd(), 'voices');
     await fs.access(distVoices).catch(async () => {


### PR DESCRIPTION
## Summary
- resolve kokoro-js path from the package root instead of a non-exported subpath

## Testing
- `npm run lint` *(fails: fetch ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_b_68615d0e8238832bba1ce5f5e33361d2